### PR TITLE
fix freeze of bn in training

### DIFF
--- a/networks/resnet_css.py
+++ b/networks/resnet_css.py
@@ -97,6 +97,7 @@ class Bottleneck(nn.Module):
 
 
 def _freeze_module(module):
+    module.eval()
     for param in module.parameters():
         param.requires_grad = False
 
@@ -152,10 +153,15 @@ class ResNet(nn.Module):
                 nn.init.constant_(m.weight, 1)
                 nn.init.constant_(m.bias, 0)
 
+    def freeze(self):    
         # Freeze first layers
         _freeze_module(self.conv1)
         _freeze_module(self.bn1)
         _freeze_module(self.layer1)
+        
+    def train(self, mode=True):
+        super(ResNet, self).train(mode)
+        freeze()
 
     def _make_layer(self, block, planes, blocks, stride=1):
         downsample = None


### PR DESCRIPTION
1. add `model.eval()` for bn
2. redefine `train()` for `ResNet` to freeze the net  whenever the `model.train()` is called.